### PR TITLE
Add universal-import/latest.json with key content

### DIFF
--- a/universal-import/latest.json
+++ b/universal-import/latest.json
@@ -1,0 +1,4 @@
+{
+  "keyId": "2dd0881b-9dc8-41a2-bfea-29fc582af5a7",
+  "publicKey": "ceLjT2Ui1jcNRC1QWbTZX2G8hjPqbiZNpGvzKxx2RVg="
+}


### PR DESCRIPTION
## Description

This PR goes hand in hand with the Universal Import - Happy Path PR: https://github.com/DopplerHQ/server/pull/4801
It's a part of the release checklist for `prd`

Its counterpart with the private key is in our Pull Requests on the server project for both `prd_dashboard` and `prd_failover_dashboard`.

These keys were generated on my machine, by using `node ./generate.js`  from the `universal-import-key-generator` repository

    UNIVERSAL_IMPORT_KEYS
    ENABLE_UNIVERSAL_IMPORT_ACCESS