### PR TITLE
Add default AWS region to CI

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -36,4 +36,5 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
           KEY_BUCKETS: ${{ secrets.KEY_BUCKETS }}


### PR DESCRIPTION
Same issue that we encountered for the `secret-agents` deploy script: In the GitHub Actions environment, the AWS CLI needs a default region, even though our commands are region-agnostic.